### PR TITLE
Fix issues with the new homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ psql postgres  # It should show 9.6.5 as the version on the prompt
 After running `psql postgres`, type the following in the prompt to verify your Postgis installation:
 
 ```sh
-drop extension postgis;  # This might fail if it wasn't previously installed
-create extension postgis;  # This should pass
+drop extension postgis;  -- This might fail if it wasn't previously installed
+create extension postgis;  -- This should pass
 select ST_Distance(
   ST_GeometryFromText('POINT(-118.4079 33.9434)', 4326), -- Los Angeles (LAX)
   ST_GeometryFromText('POINT(2.5559 49.0083)', 4326)     -- Paris (CDG)
-);  # This should print a row with 121.898285970107 as a value
+);  -- This should print a row with 121.898285970107 as a value
 ```

--- a/postgresql.rb
+++ b/postgresql.rb
@@ -18,8 +18,8 @@ class Postgresql < Formula
   depends_on "openssl"
   depends_on "readline"
 
-  depends_on :python => :optional
-  depends_on :python3 => :optional
+  depends_on "python" => :optional
+  depends_on "python3" => :optional
 
   conflicts_with "postgres-xc",
     :because => "postgresql and postgres-xc install the same binaries."


### PR DESCRIPTION
Homebrew 1.5 complains about the old "depends_on" syntax. I also updated the SQL example to use SQL comments instead of python so that it can be copied and pasted better @erinsmithclover 