### PR TITLE
[DEV-13] Revert "[DEV-13] postgres mojave update (#11)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Postgres to 9.6 and Postgis to 2.4.
 
 Homebrew will pull in the latest version of formulas when they are upgraded,
 meaning that users can inadvertently be upgraded to Postgresql 10. The
-postgresql.rb formula here ensures that 9.6.10 is installed, and the postgis.rb
+postgresql.rb formula here ensures that 9.6.8 is installed, and the postgis.rb
 formulate ensures that 2.4.4 is installed.
 
 ## Installing Postgres 9.6 and Postgis 2.4
@@ -40,7 +40,7 @@ brew install postgresql
 brew unlink postgresql
 ```
 
-The previous install of postgresql runs `initdb`, which creates database structures incompatible with 9.6.10. This needs to be removed with:
+The previous install of postgresql runs `initdb`, which creates database structures incompatible with 9.6.8. This needs to be removed with:
 
 ```sh
 rm -rf /usr/local/var/postgres
@@ -52,11 +52,11 @@ Now install Postgres from this tap with:
 brew install cloverhealth/tap/postgresql  # yes, without the homebrew-
 ```
 
-Now you will have both 9.6.10 and the latest version of Postgres installed.
-Switch to 9.6.10 with:
+Now you will have both 9.6.8 and the latest version of Postgres installed.
+Switch to 9.6.8 with:
 
 ```sh
-brew switch postgresql 9.6.10
+brew switch postgresql 9.6.8
 ```
 
 Postgis 2.4 can be installed with:
@@ -69,7 +69,7 @@ Try running and accessing Postgres with the following:
 
 ```sh
 brew services start postgresql
-psql postgres  # It should show 9.6.10 as the version on the prompt
+psql postgres  # It should show 9.6.8 as the version on the prompt
 ```
 
 After running `psql postgres`, type the following in the prompt to verify your Postgis installation:

--- a/postgresql.rb
+++ b/postgresql.rb
@@ -1,16 +1,33 @@
 class Postgresql < Formula
   desc "Object-relational database system"
   homepage "https://www.postgresql.org/"
-  url "https://ftp.postgresql.org/pub/source/v9.6.10/postgresql-9.6.10.tar.bz2"
-  sha256 "8615acc56646401f0ede97a767dfd27ce07a8ae9c952afdb57163b7234fe8426"
+  url "https://ftp.postgresql.org/pub/source/v9.6.8/postgresql-9.6.8.tar.bz2"
+  sha256 "eafdb3b912e9ec34bdd28b651d00226a6253ba65036cb9a41cad2d9e82e3eb70"
+  head "https://github.com/postgres/postgres.git"
 
-  option "with-python", "Enable PL/Python3"
+  option "without-perl", "Build without Perl support"
+  option "without-tcl", "Build without Tcl support"
+  option "with-dtrace", "Build with DTrace support"
+  option "with-python", "Enable PL/Python2"
+  option "with-python3", "Enable PL/Python3 (incompatible with --with-python)"
 
-  deprecated_option "with-python3" => "with-python"
+  deprecated_option "no-perl" => "without-perl"
+  deprecated_option "no-tcl" => "without-tcl"
+  deprecated_option "enable-dtrace" => "with-dtrace"
 
   depends_on "openssl"
   depends_on "readline"
+
   depends_on "python" => :optional
+  depends_on "python3" => :optional
+
+  conflicts_with "postgres-xc",
+    :because => "postgresql and postgres-xc install the same binaries."
+
+  fails_with :clang do
+    build 211
+    cause "Miscompilation resulting in segfault on queries"
+  end
 
   def install
     # avoid adding the SDK library directory to the linker search path
@@ -22,9 +39,9 @@ class Postgresql < Formula
     args = %W[
       --disable-debug
       --prefix=#{prefix}
-      --datadir=#{pkgshare}
-      --libdir=#{lib}
-      --sysconfdir=#{prefix}/etc
+      --datadir=#{HOMEBREW_PREFIX}/share/postgresql
+      --libdir=#{HOMEBREW_PREFIX}/lib
+      --sysconfdir=#{etc}
       --docdir=#{doc}
       --enable-thread-safety
       --with-bonjour
@@ -34,71 +51,48 @@ class Postgresql < Formula
       --with-pam
       --with-libxml
       --with-libxslt
-      --with-perl
-      --with-uuid=e2fs
     ]
 
-    if build.with?("python")
+    args << "--with-perl" if build.with? "perl"
+
+    which_python = nil
+    if build.with?("python") && build.with?("python3")
+      odie "Cannot provide both --with-python and --with-python3"
+    elsif build.with?("python") || build.with?("python3")
       args << "--with-python"
-      ENV["PYTHON"] = which("python3")
+      which_python = which(build.with?("python") ? "python" : "python3")
     end
+    ENV["PYTHON"] = which_python
 
     # The CLT is required to build Tcl support on 10.7 and 10.8 because
     # tclConfig.sh is not part of the SDK
-    if MacOS.version >= :mavericks || MacOS::CLT.installed?
+    if build.with?("tcl") && (MacOS.version >= :mavericks || MacOS::CLT.installed?)
       args << "--with-tcl"
+
       if File.exist?("#{MacOS.sdk_path}/System/Library/Frameworks/Tcl.framework/tclConfig.sh")
         args << "--with-tclconfig=#{MacOS.sdk_path}/System/Library/Frameworks/Tcl.framework"
       end
     end
 
-    # As of Xcode/CLT 10.x the Perl headers were moved from /System
-    # to inside the SDK, so we need to use `-iwithsysroot` instead
-    # of `-I` to point to the correct location.
-    # https://www.postgresql.org/message-id/153558865647.1483.573481613491501077%40wrigleys.postgresql.org
-    if DevelopmentTools.clang_build_version >= 1000
-      inreplace "configure",
-                "-I$perl_archlibexp/CORE",
-                "-iwithsysroot $perl_archlibexp/CORE"
-      inreplace "contrib/hstore_plperl/Makefile",
-                "-I$(perl_archlibexp)/CORE",
-                "-iwithsysroot $(perl_archlibexp)/CORE"
-      inreplace "src/pl/plperl/GNUmakefile",
-                "-I$(perl_archlibexp)/CORE",
-                "-iwithsysroot $(perl_archlibexp)/CORE"
-    end
+    args << "--enable-dtrace" if build.with? "dtrace"
+    args << "--with-uuid=e2fs"
 
     system "./configure", *args
     system "make"
-
-    dirs = %W[datadir=#{pkgshare} libdir=#{lib} pkglibdir=#{lib}]
-
-    # Temporarily disable building/installing the documentation.
-    # Postgresql seems to "know" the build system has been altered and
-    # tries to regenerate the documentation when using `install-world`.
-    # This results in the build failing:
-    #  `ERROR: `osx' is missing on your system.`
-    # Attempting to fix that by adding a dependency on `open-sp` doesn't
-    # work and the build errors out on generating the documentation, so
-    # for now let's simply omit it so we can package Postgresql for Mojave.
-    if DevelopmentTools.clang_build_version >= 1000
-      system "make", "all"
-      system "make", "-C", "contrib", "install", "all", *dirs
-      system "make", "install", "all", *dirs
-    else
-      system "make", "install-world", *dirs
-    end
+    system "make", "install-world", "datadir=#{pkgshare}",
+                                    "libdir=#{lib}",
+                                    "pkglibdir=#{lib}/postgresql"
   end
 
   def post_install
     (var/"log").mkpath
-    (var/name).mkpath
-    unless File.exist? "#{var}/#{name}/PG_VERSION"
-      system "#{bin}/initdb", "#{var}/#{name}"
+    (var/"postgres").mkpath
+    unless File.exist? "#{var}/postgres/PG_VERSION"
+      system "#{bin}/initdb", "#{var}/postgres"
     end
   end
 
-  def caveats; <<~EOS
+  def caveats; <<-EOS
     If builds of PostgreSQL 9 are failing and you have version 8.x installed,
     you may need to remove the previous version first. See:
       https://github.com/Homebrew/legacy-homebrew/issues/2510
@@ -110,13 +104,13 @@ class Postgresql < Formula
       https://www.postgresql.org/docs/9.6/static/pgupgrade.html
 
       You will need your previous PostgreSQL installation from brew to perform `pg_upgrade`.
-        Do not run `brew cleanup postgresql@9.6` until you have performed the migration.
-  EOS
+      Do not run `brew cleanup postgresql` until you have performed the migration.
+    EOS
   end
 
-  plist_options :manual => "pg_ctl -D #{HOMEBREW_PREFIX}/var/postgresql start"
+  plist_options :manual => "pg_ctl -D #{HOMEBREW_PREFIX}/var/postgres start"
 
-  def plist; <<~EOS
+  def plist; <<-EOS
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
     <plist version="1.0">
@@ -129,23 +123,23 @@ class Postgresql < Formula
       <array>
         <string>#{opt_bin}/postgres</string>
         <string>-D</string>
-        <string>#{var}/#{name}</string>
+        <string>#{var}/postgres</string>
       </array>
       <key>RunAtLoad</key>
       <true/>
       <key>WorkingDirectory</key>
       <string>#{HOMEBREW_PREFIX}</string>
       <key>StandardErrorPath</key>
-      <string>#{var}/log/#{name}.log</string>
+      <string>#{var}/log/postgres.log</string>
     </dict>
     </plist>
-  EOS
+    EOS
   end
 
   test do
     system "#{bin}/initdb", testpath/"test"
-    assert_equal pkgshare.to_s, shell_output("#{bin}/pg_config --sharedir").chomp
-    assert_equal lib.to_s, shell_output("#{bin}/pg_config --libdir").chomp
-    assert_equal lib.to_s, shell_output("#{bin}/pg_config --pkglibdir").chomp
+    assert_equal "#{HOMEBREW_PREFIX}/share/postgresql", shell_output("#{bin}/pg_config --sharedir").chomp
+    assert_equal "#{HOMEBREW_PREFIX}/lib", shell_output("#{bin}/pg_config --libdir").chomp
+    assert_equal "#{HOMEBREW_PREFIX}/lib/postgresql", shell_output("#{bin}/pg_config --pkglibdir").chomp
   end
 end


### PR DESCRIPTION
This reverts commit 16eef53a5112e8127bee4265cd917140c394563b. (Reverts #11)

Postgis doesn't correctly install against this postgres installation so reverting for now.

I suspect the problem is that I didn't get the edits to the paths quite correct while adapting the Homebrew recipe for Postgres 9.6.10, we can try again and make sure to test creating the postgis extension before merging.