### PR TITLE
[DEV-28] Update postgis version to 2.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # homebrew-tap
 
 This is Clover Health's Homebrew Tap, which features formulas to help pin
-Postgres to 9.6 and Postgis to 2.4.
+Postgres to 9.6 and Postgis to 2.5.
 
 Homebrew will pull in the latest version of formulas when they are upgraded,
 meaning that users can inadvertently be upgraded to Postgresql 10. The
 postgresql.rb formula here ensures that 9.6.10 is installed, and the postgis.rb
-formulate ensures that 2.4.4 is installed.
+formulate ensures that 2.5.2 is installed.
 
-## Installing Postgres 9.6 and Postgis 2.4
+## Installing Postgres 9.6 and Postgis 2.5
 
 First ensure you have upgraded to the latest homebrew:
 
@@ -59,7 +59,7 @@ Switch to 9.6.10 with:
 brew switch postgresql 9.6.10
 ```
 
-Postgis 2.4 can be installed with:
+Postgis 2.5 can be installed with:
 
 ```sh
 brew install cloverhealth/tap/postgis

--- a/postgis.rb
+++ b/postgis.rb
@@ -1,8 +1,8 @@
 class Postgis < Formula
   desc "Adds support for geographic objects to PostgreSQL"
   homepage "https://postgis.net/"
-  url "https://download.osgeo.org/postgis/source/postgis-2.4.4.tar.gz"
-  sha256 "0663efb589210d5048d95c817e5cf29552ec8180e16d4c6ef56c94255faca8c2"
+  url "https://download.osgeo.org/postgis/source/postgis-2.5.2.tar.gz"
+  sha256 "b6cb286c5016029d984f8c440947bf9178da72e1f6f840ed639270e1c451db5e"
   revision 1
 
   head do


### PR DESCRIPTION
This updates postgis to a version that's compatible with proj 6.0.0 (see #16) and brings it up to the latest version of postgis.

Fixes #16.