### PR TITLE
Fix build failure on latest Mac OSX with gcc Werror turned on.

### DIFF
--- a/postgresql.rb
+++ b/postgresql.rb
@@ -12,7 +12,7 @@ class Postgresql < Formula
     ENV["XML2_CONFIG"] = "xml2-config --exec-prefix=/usr"
 
     ENV.prepend "LDFLAGS", "-L#{Formula["openssl"].opt_lib} -L#{Formula["readline"].opt_lib}"
-    ENV.prepend "CPPFLAGS", "-I#{Formula["openssl"].opt_include} -I#{Formula["readline"].opt_include}"
+    ENV.prepend "CPPFLAGS", "-I#{Formula["openssl"].opt_include} -I#{Formula["readline"].opt_include} -Wno-error-all"
 
     args = %W[
       --disable-debug


### PR DESCRIPTION
### What does this change do?
On some latest version of OSX, e.g. 10.15, clang 12.0.0 have `-Werror` default enabled, which leads to build error for postgresql 9.6.10, I tried 9.6.21 it seems build ok. I don't know if we can update the postgresql version here, so this workaround is to disabled `-Werror` using `CPPFLAGS`.

### How has this change been tested?
I have forked a version to https://github.com/lganclover/homebrew-tap, and tested locally it can pass the build phase on 
 MacOSX 10.15, clang 12.0.0

References: https://www.postgresql.org/message-id/18506.1507647675%40sss.pgh.pa.us

P.S: I don't know if there is any JIRA related to similar issue, if so I can link to them.
